### PR TITLE
PPA for libgit2 has moved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - sourceline: ppa:opencpu/libgit2
+      - sourceline: ppa:jeroen/libgit2
       # sudo apt-get install software-properties-common gnupg gnupg-agent
       # sudo add-apt-repository -y ppa:opencpu/libgit2
     packages:


### PR DESCRIPTION
Can you please make the same change for your other repositories: https://github.com/search?q=%22ppa%3Aopencpu%2Flibgit2%22&type=Code